### PR TITLE
fix: content-index workflow — oprava selhání na protected branch

### DIFF
--- a/.github/workflows/content-index.yml
+++ b/.github/workflows/content-index.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
@@ -23,10 +24,25 @@ jobs:
       - name: Generate content index
         run: node scripts/generate-content-index.mjs
 
-      - name: Commit if changed
+      - name: Create PR and merge
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add content-index.json
-          git diff --cached --quiet || git commit -m "chore: update content-index.json"
-          git push
+          if git diff --cached --quiet; then
+            echo "No changes to content-index.json, skipping."
+            exit 0
+          fi
+          BRANCH="chore/update-content-index-$(date +%s)"
+          git checkout -b "$BRANCH"
+          git commit -m "chore: update content-index.json"
+          git push origin "$BRANCH"
+          PR_URL=$(gh pr create \
+            --title "chore: update content-index.json" \
+            --body "Automaticky vygenerovaný index článků po změně obsahu." \
+            --base main \
+            --head "$BRANCH")
+          PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+          gh pr merge "$PR_NUMBER" --squash --delete-branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problém

GitHub Actions bot nemůže pushovat přímo na `main` (protected branch). Na personal repozitářích GitHub neumožňuje přidat `github-actions[bot]` do bypass listu — to je pouze pro organizace.

**Chyba:**
```
remote: error: GH006: Protected branch update failed
remote: - Changes must be made through a pull request.
```

## Řešení

Workflow nyní:
1. Vygeneruje `content-index.json`
2. Pokud se soubor změnil, vytvoří dočasnou větev `chore/update-content-index-{timestamp}`
3. Vytvoří PR
4. Okamžitě ho merguje (`gh pr merge --squash`) — funguje protože `required_approving_review_count: 0`
5. Smaže dočasnou větev

Pokud se `content-index.json` nezměnil, workflow tiše skončí bez commitu.

## Test plan

- [ ] Mergovat tento PR
- [ ] Commitnout změnu v `content/posts/` na větvi → merge do main → zkontrolovat že workflow proběhne bez chyby

🤖 Generated with [Claude Code](https://claude.com/claude-code)