### PR TITLE
feat: NewsletterCTA na kategoriové stránky a stránku článku

### DIFF
--- a/src/app/(cs)/[slug]/page.tsx
+++ b/src/app/(cs)/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { RecipeMetaBox } from "@/components/article/RecipeMetaBox";
 import { AuthorBio } from "@/components/article/AuthorBio";
 import { AffiliateDisclosure } from "@/components/article/AffiliateDisclosure";
 import { RelatedArticles } from "@/components/article/RelatedArticles";
+import { NewsletterCTA } from "@/components/ui/NewsletterCTA";
 
 export function generateStaticParams() {
   return getAllPosts().map((post) => ({ slug: post.slug }));
@@ -122,6 +123,9 @@ export default async function ArticlePage({
 
       {/* Related articles */}
       <RelatedArticles posts={related} locale="cs" />
+
+      {/* Newsletter CTA */}
+      <NewsletterCTA />
     </>
   );
 }

--- a/src/components/layout/CategoryPage.tsx
+++ b/src/components/layout/CategoryPage.tsx
@@ -2,6 +2,7 @@ import type { Post } from "@/lib/content";
 import type { Locale } from "@/lib/i18n";
 import { ArticleGrid } from "@/components/article/ArticleGrid";
 import { CategoryFilterGrid } from "@/components/article/CategoryFilterGrid";
+import { NewsletterCTA } from "@/components/ui/NewsletterCTA";
 
 interface CategoryPageProps {
   title: string;
@@ -28,6 +29,7 @@ export function CategoryPage({
   const resolvedMoreHeading = moreHeading ?? `Další ${title.toLowerCase()}`;
 
   return (
+    <>
     <section className="mx-auto max-w-[75rem] px-6 pt-12 pb-24">
       {/* Page header */}
       <div className="mb-12">
@@ -59,5 +61,8 @@ export function CategoryPage({
         />
       )}
     </section>
+
+    <NewsletterCTA />
+    </>
   );
 }


### PR DESCRIPTION
## Shrnutí

- Přidána sekce pro přihlášení k newsletteru na stránky `/recepty`, `/navody`, `/recenze` (přes `CategoryPage`)
- Přidána sekce pro přihlášení k newsletteru na konec každého článku (za related articles)

## Test plan

- [ ] Recepty, Navody, Recenze — newsletter sekce zobrazena dole pod gridem
- [ ] Stránka článku — newsletter sekce zobrazena za related articles

🤖 Generated with [Claude Code](https://claude.com/claude-code)