### PR TITLE
fix: content-index workflow — použít PAT pro bypass branch protection

### DIFF
--- a/.github/workflows/content-index.yml
+++ b/.github/workflows/content-index.yml
@@ -13,6 +13,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_PAT }}
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Problém
Workflow `update-index` failuje při push do `main` protože branch protection vyžaduje PR.
`github-actions[bot]` s výchozím `GITHUB_TOKEN` nemá oprávnění obejít toto pravidlo.

## Řešení
Použít PAT token (`GH_PAT`) uložený jako repository secret.
Admin PAT může pushovat přímo do chráněné větve.

## Setup (nutný před mergem)
1. Vytvoř PAT: https://github.com/settings/tokens → classic → scope `repo`
2. Přidej jako secret: https://github.com/PeMajer/griluju/settings/secrets/actions → `GH_PAT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)